### PR TITLE
Replace deprecated LightGraphs.jl with Graphs.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -15,7 +15,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 DataStructures = "0.18"
-LightGraphs = "1"
 StatsBase = "0.33"
 julia = "1"
 

--- a/src/VertexEliminationOrder.jl
+++ b/src/VertexEliminationOrder.jl
@@ -1,6 +1,6 @@
 module VertexEliminationOrder
 
-using LightGraphs
+using Graphs
 using DataStructures
 using StatsBase
 using Parameters

--- a/test/test_dissection.jl
+++ b/test/test_dissection.jl
@@ -1,6 +1,6 @@
 using VertexEliminationOrder
 using Test
-using LightGraphs
+using Graphs
 
 ENV["JULIA_DEBUG"]=VertexEliminationOrder
 

--- a/test/test_flowcutter.jl
+++ b/test/test_flowcutter.jl
@@ -1,6 +1,6 @@
 using VertexEliminationOrder
 using Test
-using LightGraphs
+using Graphs
 using SparseArrays
 
 

--- a/test/test_heuristics.jl
+++ b/test/test_heuristics.jl
@@ -1,6 +1,6 @@
 using VertexEliminationOrder
 using Test
-using LightGraphs
+using Graphs
 
 G = smallgraph("house")
 @info "Testing minwidth with house graph"

--- a/test/test_perf.jl
+++ b/test/test_perf.jl
@@ -1,4 +1,4 @@
-using LightGraphs
+using Graphs
 using Test
 using Pkg
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,5 +1,5 @@
 using VertexEliminationOrder
-using LightGraphs
+using Graphs
 using Test
 using Random
 


### PR DESCRIPTION
[LightGraphs](https://github.com/sbromberger/LightGraphs.jl) is deprecated.
It's functionality has been moved to [Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl)